### PR TITLE
Add Kubernetes manifests and Helm chart for deployment

### DIFF
--- a/helm/wotlwedu-minimal/Chart.yaml
+++ b/helm/wotlwedu-minimal/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: wotlwedu-minimal
+version: 0.1.0
+description: A Helm chart for deploying the wotlwedu-minimal frontend
+appVersion: "1.0.0"
+type: application

--- a/helm/wotlwedu-minimal/templates/_helpers.tpl
+++ b/helm/wotlwedu-minimal/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{- define "wotlwedu-minimal.labels" -}}
+app.kubernetes.io/name: {{ include "wotlwedu-minimal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "wotlwedu-minimal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wotlwedu-minimal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "wotlwedu-minimal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wotlwedu-minimal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "wotlwedu-minimal.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/wotlwedu-minimal/templates/deployment.yaml
+++ b/helm/wotlwedu-minimal/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wotlwedu-minimal.fullname" . }}
+  labels:
+    {{- include "wotlwedu-minimal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wotlwedu-minimal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "wotlwedu-minimal.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "wotlwedu-minimal.fullname" . }}
+      {{- else if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.httpPort }}
+              name: http
+            - containerPort: {{ .Values.service.httpsPort }}
+              name: https
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.tlsSecret.name }}
+          volumeMounts:
+            - name: tls-certificates
+              mountPath: {{ .Values.tlsSecret.mountPath }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.tlsSecret.name }}
+      volumes:
+        - name: tls-certificates
+          secret:
+            secretName: {{ .Values.tlsSecret.name }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/wotlwedu-minimal/templates/ingress.yaml
+++ b/helm/wotlwedu-minimal/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "wotlwedu-minimal.fullname" . }}
+  labels:
+    {{- include "wotlwedu-minimal.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - secretName: {{ .secretName }}
+      hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "wotlwedu-minimal.fullname" $ }}
+                port:
+                  {{- if eq .servicePort "https" }}
+                  number: {{ $.Values.service.httpsPort }}
+                  {{- else if eq .servicePort "http" }}
+                  number: {{ $.Values.service.httpPort }}
+                  {{- else }}
+                  name: {{ .servicePort }}
+                  {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/wotlwedu-minimal/templates/service.yaml
+++ b/helm/wotlwedu-minimal/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wotlwedu-minimal.fullname" . }}
+  labels:
+    {{- include "wotlwedu-minimal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "wotlwedu-minimal.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+    - name: https
+      port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      protocol: TCP

--- a/helm/wotlwedu-minimal/templates/serviceaccount.yaml
+++ b/helm/wotlwedu-minimal/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wotlwedu-minimal.fullname" . }}
+  labels:
+    {{- include "wotlwedu-minimal.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/wotlwedu-minimal/templates/tls-secret.yaml
+++ b/helm/wotlwedu-minimal/templates/tls-secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.tlsSecret.create }}
+{{- $crt := required "tlsSecret.certificate must be provided when tlsSecret.create is true" .Values.tlsSecret.certificate -}}
+{{- $key := required "tlsSecret.privateKey must be provided when tlsSecret.create is true" .Values.tlsSecret.privateKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.tlsSecret.name }}
+  labels:
+    {{- include "wotlwedu-minimal.labels" . | nindent 4 }}
+    {{- with .Values.tlsSecret.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.tlsSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $crt | b64enc | quote }}
+  tls.key: {{ $key | b64enc | quote }}
+{{- end }}

--- a/helm/wotlwedu-minimal/values.yaml
+++ b/helm/wotlwedu-minimal/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 2
+
+image:
+  repository: ravelox/wotlwedu-minimal
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  httpPort: 80
+  httpsPort: 443
+
+env:
+  WOTLWEDU_API_URL: https://api.wotlwedu.com:9876/
+  WOTLWEDU_SERVER_NAME: mobile.wotlwedu.com
+  WOTLWEDU_SSL_CERT_FILE: /etc/wotlwedu/tls/tls.crt
+  WOTLWEDU_SSL_KEY_FILE: /etc/wotlwedu/tls/tls.key
+
+resources: {}
+
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: mobile.wotlwedu.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: http
+  tls:
+    - secretName: wotlwedu-minimal-tls
+      hosts:
+        - mobile.wotlwedu.com
+
+tlsSecret:
+  create: false
+  name: wotlwedu-minimal-tls
+  annotations: {}
+  labels: {}
+  certificate: ""
+  privateKey: ""
+  mountPath: /etc/wotlwedu/tls

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wotlwedu-minimal
+  labels:
+    app: wotlwedu-minimal
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wotlwedu-minimal
+  template:
+    metadata:
+      labels:
+        app: wotlwedu-minimal
+    spec:
+      containers:
+        - name: wotlwedu-minimal
+          image: ravelox/wotlwedu-minimal:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http
+            - containerPort: 443
+              name: https
+          env:
+            - name: WOTLWEDU_API_URL
+              value: https://api.wotlwedu.com:9876/
+            - name: WOTLWEDU_SERVER_NAME
+              value: mobile.wotlwedu.com
+            - name: WOTLWEDU_SSL_CERT_FILE
+              value: /etc/wotlwedu/tls/tls.crt
+            - name: WOTLWEDU_SSL_KEY_FILE
+              value: /etc/wotlwedu/tls/tls.key
+          volumeMounts:
+            - name: tls-certificates
+              mountPath: /etc/wotlwedu/tls
+              readOnly: true
+      volumes:
+        - name: tls-certificates
+          secret:
+            secretName: wotlwedu-minimal-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wotlwedu-minimal
+  labels:
+    app: wotlwedu-minimal
+spec:
+  type: ClusterIP
+  selector:
+    app: wotlwedu-minimal
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: https
+      protocol: TCP

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wotlwedu-minimal
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  tls:
+    - hosts:
+        - mobile.wotlwedu.com
+      secretName: wotlwedu-minimal-tls
+  rules:
+    - host: mobile.wotlwedu.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wotlwedu-minimal
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary
- add base Kubernetes manifests for the wotlwedu-minimal deployment, service, and ingress with TLS secret support
- provide a Helm chart that templates the deployment, service, ingress, and optional TLS secret creation for configurable installs

## Testing
- helm lint helm/wotlwedu-minimal *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb40ece02c8321b7caef9e311766b0